### PR TITLE
Fixed item overlap when bought consecutively from terminal.

### DIFF
--- a/NetworkHandler/QuickBuyNetworkHandler.cs
+++ b/NetworkHandler/QuickBuyNetworkHandler.cs
@@ -43,10 +43,14 @@ namespace QuickBuyMenu.NetworkHandler
                 if (obj.TryGet(out targetObject))
                 {
                     GrabbableObject clientItem = targetObject.GetComponent<GrabbableObject>();
+
+                    if (playerController.currentlyGrabbingObject != null)
+                        playerController.currentlyGrabbingObject.EnableItemMeshes(false);
+
                     clientItem.EnableItemMeshes(true);
                     clientItem.playerHeldBy = playerController;
                     clientItem.playerHeldBy.currentlyGrabbingObject = clientItem;
-                    playerController.currentlyHeldObjectServer = clientItem;
+                    clientItem.playerHeldBy.currentlyHeldObjectServer = clientItem;
 
                     if (!(NetworkManager.Singleton.IsHost && !NetworkManager.Singleton.IsServer))
                     {

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ If you want to contribute code or documentation to the project, you are welcome 
 
 All notable changes to this project will be documented in this section.
 
+## [1.0.3] - 01/10/2024
+
+- Fixed [github issue #6](https://github.com/jakemaguy/QuickBuyMenu/issues/6) where single handed items bought from Quick Buy were overlapping if you bought multiple items consecutively, without exiting the terminal.
+
 ## [1.0.2] - 01/10/2024
 
 - Fixed [github issue #5](https://github.com/jakemaguy/QuickBuyMenu/issues/5) where hyphens `-` weren't parsed correctly.


### PR DESCRIPTION
This PR fixes #6 

Checks if the current player already has an equipped terminal item and disables the mesh before adding the new item to your inventory.